### PR TITLE
HSL/CMYK convenience category on UIColor

### DIFF
--- a/NFAllocInit/Categories/UIColor+NFAllocInit.h
+++ b/NFAllocInit/Categories/UIColor+NFAllocInit.h
@@ -13,6 +13,12 @@
 + (UIColor *)colorForHex:(NSString *)hexColor;
 + (UIColor *)colorForHex:(NSString *)hexColor alpha:(CGFloat)alpha;
 
++ (UIColor *)colorWithHue:(CGFloat)hue saturation:(CGFloat)saturation luminance:(CGFloat)luminance;
++ (UIColor *)colorWithHue:(CGFloat)hue saturation:(CGFloat)saturation luminance:(CGFloat)luminance alpha:(CGFloat)alpha;
+
++ (UIColor *)colorWithCyan:(CGFloat)cyan magenta:(CGFloat)magenta yellow:(CGFloat)yellow key:(CGFloat)key;
++ (UIColor *)colorWithCyan:(CGFloat)cyan magenta:(CGFloat)magenta yellow:(CGFloat)yellow key:(CGFloat)key alpha:(CGFloat)alpha;
+
 - (NSString*)hexValue;
 - (NSString*)hexValueWithAlpha;
 
@@ -21,5 +27,8 @@
 - (UIColor *)colorByFadingColor;
 - (UIColor *)colorByChangingAlphaTo:(CGFloat)newAlpha;
 - (UIColor *)colorByMuliplyingComponentsBy:(float)factor;
+
+- (BOOL)getHue:(nullable CGFloat *)hue saturation:(nullable CGFloat *)saturation luminance:(nullable CGFloat *)luminance alpha:(nullable CGFloat *)alpha;
+- (BOOL)getCyan:(nullable CGFloat *)cyan magenta:(nullable CGFloat *)magenta yellow:(nullable CGFloat *)yellow key:(nullable CGFloat *)key alpha:(nullable CGFloat *)alpha;
 
 @end

--- a/NFAllocInit/Categories/UIColor+NFAllocInit.h
+++ b/NFAllocInit/Categories/UIColor+NFAllocInit.h
@@ -28,6 +28,8 @@
 - (UIColor *)colorByChangingAlphaTo:(CGFloat)newAlpha;
 - (UIColor *)colorByMuliplyingComponentsBy:(float)factor;
 
+- (UIColor *)colorByLerpingToColor:(UIColor *)targetColor delta:(float)delta;
+
 - (BOOL)getHue:(nullable CGFloat *)hue saturation:(nullable CGFloat *)saturation luminance:(nullable CGFloat *)luminance alpha:(nullable CGFloat *)alpha;
 - (BOOL)getCyan:(nullable CGFloat *)cyan magenta:(nullable CGFloat *)magenta yellow:(nullable CGFloat *)yellow key:(nullable CGFloat *)key alpha:(nullable CGFloat *)alpha;
 

--- a/NFAllocInit/Categories/UIColor+NFAllocInit.m
+++ b/NFAllocInit/Categories/UIColor+NFAllocInit.m
@@ -8,6 +8,8 @@
 
 #import "UIColor+NFAllocInit.h"
 
+#define CLAMP(VAL,LOW,HIGH) MAX(LOW,MIN(HIGH,VAL))
+
 @implementation UIColor (NFAllocInit)
 
 + (UIColor *) colorForHex:(NSString *)hexColor {
@@ -69,6 +71,53 @@
                            alpha:alpha];
 }
 
++ (UIColor *) colorWithHue:(CGFloat)hue saturation:(CGFloat)saturation luminance:(CGFloat)luminance {
+    return [UIColor colorWithHue:hue saturation:saturation luminance:luminance alpha:1.0];
+}
+
++ (UIColor *) colorWithHue:(CGFloat)hue saturation:(CGFloat)saturation luminance:(CGFloat)luminance alpha:(CGFloat)alpha {
+    CGFloat h = CLAMP(hue, 0, 1) * 6;
+    CGFloat s = CLAMP(saturation, 0, 1);
+    CGFloat l = CLAMP(luminance, 0, 1);
+    CGFloat r = l, g = l, b = l, v = 0;
+    
+    if (l < 0.5) {
+        v = l * (1 + s);
+    } else {
+        v = (l + s) - (s * l);
+    }
+    
+    if (v > 0) {
+        CGFloat m = l + l - v;
+        CGFloat sv = (v - m) / v;
+        CGFloat vsf = v * sv * (h - (int)h);
+        CGFloat mid1 = m + vsf, mid2 = v - vsf;
+        
+        int sextant = (int)h % 6;
+        switch (sextant) {
+            case 0: { r = v; g = mid1; b = m; break; }
+            case 1: { r = mid2; g = v; b = m; break; }
+            case 2: { r = m; g = v; b = mid1; break; }
+            case 3: { r = m; g = mid2; b = v; break; }
+            case 4: { r = mid1; g = m; b = v; break; }
+            case 5: { r = v; g = m; b = mid2; break; }
+        }
+    }
+    
+    return [UIColor colorWithRed:r green:g blue:b alpha:CLAMP(alpha, 0, 1)];
+}
+
++ (UIColor *) colorWithCyan:(CGFloat)cyan magenta:(CGFloat)magenta yellow:(CGFloat)yellow key:(CGFloat)key {
+    return [UIColor colorWithCyan:cyan magenta:magenta yellow:yellow key:key alpha:1.0];
+}
+
++ (UIColor *) colorWithCyan:(CGFloat)cyan magenta:(CGFloat)magenta yellow:(CGFloat)yellow key:(CGFloat)key alpha:(CGFloat)alpha {
+    CGFloat k = CLAMP(key, 0, 1);
+    CGFloat r = 1 - MIN(1, CLAMP(cyan, 0, 1) * (1 - k) + k);
+    CGFloat g = 1 - MIN(1, CLAMP(magenta, 0, 1) * (1 - k) + k);
+    CGFloat b = 1 - MIN(1, CLAMP(yellow, 0, 1) * (1 - k) + k);
+    return [UIColor colorWithRed:r green:g blue:b alpha:CLAMP(alpha, 0, 1)];
+}
 
 - (NSString*)hexValue {
     CGColorRef color = [self CGColor];
@@ -235,6 +284,100 @@
 	CGColorRelease(newColor);
     
 	return retColor;
+}
+
+- (BOOL)getHue:(nullable CGFloat *)hue saturation:(nullable CGFloat *)saturation luminance:(nullable CGFloat *)luminance alpha:(nullable CGFloat *)alpha
+{
+    CGFloat r = 0, g = 0, b = 0, a = 0;
+    CGFloat h = 0, s = 0, l = 0;
+    if (![self getRed:&r green:&g blue:&b alpha:&a]) {
+        return NO;
+    }
+    
+    CGFloat v = MAX(MAX(r, g), b);
+    CGFloat m = MIN(MIN(r, g), b);
+    l = (m + v) / 2.0;
+    
+    if (l > 0) {
+        CGFloat vm = v - m;
+        s = vm;
+        
+        if (s > 0) {
+            if (l <= 0.5) {
+                s /= v + m;
+            } else {
+                s /= 2 - v - m;
+            }
+            
+            CGFloat r2 = (v - r) / vm;
+            CGFloat g2 = (v - g) / vm;
+            CGFloat b2 = (v - b) / vm;
+            if (r == v && g == m) {
+                h = 5 + b2;
+            } else if (r == v && g != m) {
+                h = 1 - g2;
+            } else if (g == v && b == m) {
+                h = 1 + r2;
+            } else if (g == v && b != m) {
+                h = 3 - b2;
+            } else if (r == m) {
+                h = 3 + g2;
+            } else {
+                h = 5 - r2;
+            }
+        }
+    }
+    
+    h /= 6;
+    if (h == 1) {
+        h = 0;
+    }
+    
+    if (hue)
+        *hue = h;
+    if (saturation)
+        *saturation = s;
+    if (luminance)
+        *luminance = l;
+    if (alpha)
+        *alpha = a;
+    
+    return YES;
+}
+
+- (BOOL)getCyan:(nullable CGFloat *)cyan magenta:(nullable CGFloat *)magenta yellow:(nullable CGFloat *)yellow key:(nullable CGFloat *)key alpha:(nullable CGFloat *)alpha
+{
+    CGFloat r = 0, g = 0, b = 0, a = 0;
+    CGFloat c = 0, m = 0, y = 0, k = 0;
+    if (![self getRed:&r green:&g blue:&b alpha:&a]) {
+        return NO;
+    }
+    
+    if (r == 0 && g == 0 && b == 0) {
+        k = 1;
+        
+    } else {
+        c = 1 - r;
+        m = 1 - g;
+        y = 1 - b;
+        k = MIN(MIN(c, m), y);
+        c = (c - k) / (1 - k);
+        m = (m - k) / (1 - k);
+        y = (y - k) / (1 - k);
+    }
+    
+    if (cyan)
+        *cyan = c;
+    if (magenta)
+        *magenta = m;
+    if (yellow)
+        *yellow = y;
+    if (key)
+        *key = k;
+    if (alpha)
+        *alpha = a;
+    
+    return YES;
 }
 
 @end

--- a/NFAllocInit/Categories/UIColor+NFAllocInit.m
+++ b/NFAllocInit/Categories/UIColor+NFAllocInit.m
@@ -286,6 +286,19 @@
 	return retColor;
 }
 
+- (UIColor *)colorByLerpingToColor:(UIColor *)targetColor delta:(float)delta
+{
+    CGFloat srcHue, srcSaturation, srcBrightness, srcAlpha, destHue, destSaturation, destBrightness, destAlpha;
+    if (![self getHue:&srcHue saturation:&srcSaturation brightness:&srcBrightness alpha:&srcAlpha])
+        return self;
+    if (![targetColor getHue:&destHue saturation:&destSaturation brightness:&destBrightness alpha:&destAlpha])
+        return self;
+    return [UIColor colorWithHue:srcHue + (destHue - srcHue) * delta
+                      saturation:srcSaturation + (destSaturation - srcSaturation) * delta
+                      brightness:srcBrightness + (destBrightness - srcBrightness) * delta
+                           alpha:srcAlpha + (destAlpha - srcAlpha) * delta];
+}
+
 - (BOOL)getHue:(nullable CGFloat *)hue saturation:(nullable CGFloat *)saturation luminance:(nullable CGFloat *)luminance alpha:(nullable CGFloat *)alpha
 {
     CGFloat r = 0, g = 0, b = 0, a = 0;


### PR DESCRIPTION
By default, `UIColor` has an initializer for HSB, but not HSL or CMYK.

This PR adds the following class functions that create instances of `UIColor` for HSL and CMYK:
`colorWithHue:saturation:luminance:`
`colorWithHue:saturation:luminance:alpha:`
`colorWithCyan:magenta:yellow:key:`
`colorWithCyan:magenta:yellow:key:alpha:`

It also adds component getters in line with the RGB and HSB ones provided by default:
`getHue:saturation:luminance:alpha:`
`getCyan:magenta:yellow:key:alpha:`

Finally, it adds a function to allow linear interpolation between colours.
`colorByLerpingToColor:delta:`

This is based on HSB rather than RGB, so that it is a smooth transition by hue.  For example, yellow and green are adjacent on the colour wheel, but interpolating by their RGB values (255, 0, 255) and (0, 255, 0) will cause it to pass through grey (128, 128, 128).  Interpolating by HSB will adjust by hue, as expected.

Note the difference between the system provided HSB/HSV and HSL:
The "brightness" or "value" in HSB/HSV scales the colour from black (0) to fullbright (1).  The "luminance" component in HSL scales the colour from black (0) to white (1), where 0.5 is fullbright.
https://en.wikipedia.org/wiki/HSL_and_HSV

The K in CMYK officially stands for "key", as it used to line up the separate colour layers in printing, but it is generally the component used for black so as to save on ink.
https://en.wikipedia.org/wiki/CMYK_color_model
