### PR TITLE
Enums to NS_ENUM for Swift integration

### DIFF
--- a/NFAllocInit/NFProperty.h
+++ b/NFAllocInit/NFProperty.h
@@ -8,13 +8,13 @@
 
 #import <Foundation/Foundation.h>
 
-typedef enum  {
+typedef NS_ENUM(NSInteger, NFPropertyValueType) {
     NFPropertyValueTypeUnknown,
     NFPropertyValueTypeObject,
     NFPropertyValueTypePrimitive
-} NFPropertyValueType;
+};
 
-typedef enum {
+typedef NS_ENUM(NSInteger, NFPropertyDataType) {
     NFPropertyDataTypeUnknown,
     NFPropertyDataTypeInt,
     NFPropertyDataTypeUnsignedInt,
@@ -26,8 +26,8 @@ typedef enum {
     NFPropertyDataTypeUnsignedShort,
     NFPropertyDataTypeChar,
     NFPropertyDataTypeUnsignedChar,
-    NFPropertyDataTypeObject,
-} NFPropertyDataType;
+    NFPropertyDataTypeObject
+};
 
 @interface NFProperty : NSObject
 

--- a/NFAllocInit/NFResourceUtils.h
+++ b/NFAllocInit/NFResourceUtils.h
@@ -6,7 +6,7 @@
 
 #import <Foundation/Foundation.h>
 
-typedef enum {
+typedef NS_ENUM(NSInteger, FileType) {
     FileTypePNG,
     FileTypeJPG,
     FileTypeVideo,
@@ -15,7 +15,7 @@ typedef enum {
     FileTypeJson,
     FileTypeText,
     FileTypeUnknown
-} FileType;
+};
 
 @interface NFResourceUtils : NSObject
 


### PR DESCRIPTION
Change `enum` to `NS_ENUM` so that Xcode will convert it to a Swift enum automatically.
